### PR TITLE
Datastream/Dataset Implementation Proposal

### DIFF
--- a/src/main/scala/scalaz/analytics/AnalyticsModule.scala
+++ b/src/main/scala/scalaz/analytics/AnalyticsModule.scala
@@ -10,9 +10,9 @@ import scala.language.implicitConversions
 trait AnalyticsModule {
 
   /**
-   * An abstract Dataset
+   * An abstract DataSet
    */
-  type Dataset[A]
+  type DataSet[A]
 
   /**
    * An abstract DataStream.
@@ -20,7 +20,7 @@ trait AnalyticsModule {
   type DataStream[A]
 
   /**
-   * A window is a way to specify a view on a DataStream/Dataset
+   * A window is a way to specify a view on a DataStream/DataSet
    */
   sealed trait Window
 
@@ -97,12 +97,12 @@ trait AnalyticsModule {
   }
 
   /**
-   * The dataset/datastream operations of scalaz-analytics
+   * The DataSet/DataStream operations of scalaz-analytics
    */
   trait Ops[F[_]] {
     // Unbounded
     def map[A, B](ds: F[A])(f: A =>: B): F[B]
-    def filter[A, B](ds: F[A])(f: A =>: Boolean): F[A]
+    def filter[A](ds: F[A])(f: A =>: Boolean): F[A]
 
     // Bounded
     def fold[A, B](ds: F[A])(window: Window)(initial: A =>: B)(f: (B, A) =>: B): F[B]
@@ -149,20 +149,20 @@ trait AnalyticsModule {
   }
 
   /**
-   * A DSL for building the Dataset data structure
+   * A DSL for building the DataSet data structure
    */
-  implicit class DatasetSyntax[A](ds: Dataset[A])(implicit A: Type[A]) {
+  implicit class DataSetSyntax[A](ds: DataSet[A])(implicit A: Type[A]) {
 
-    def map[B: Type](f: (A =>: A) => (A =>: B)): Dataset[B] =
+    def map[B: Type](f: (A =>: A) => (A =>: B)): DataSet[B] =
       setOps.map(ds)(f(stdLib.id))
 
-    def filter(f: (A =>: A) => (A =>: Boolean)): Dataset[A] =
+    def filter(f: (A =>: A) => (A =>: Boolean)): DataSet[A] =
       setOps.filter(ds)(f(stdLib.id))
 
-    def fold[B: Type](init: A =>: B)(f: (B, A) =>: B): Dataset[B] =
+    def fold[B: Type](init: A =>: B)(f: (B, A) =>: B): DataSet[B] =
       setOps.fold(ds)(Window.GlobalWindow())(init)(f)
 
-    def distinct: Dataset[A] =
+    def distinct: DataSet[A] =
       setOps.distinct(ds)(Window.GlobalWindow())
   }
 
@@ -185,9 +185,9 @@ trait AnalyticsModule {
   }
 
   /**
-   * Create an empty Dataset of type A
+   * Create an empty DataSet of type A
    */
-  def empty[A: Type]: Dataset[A]
+  def empty[A: Type]: DataSet[A]
 
   /**
    * Create an empty DataStream of type A
@@ -208,7 +208,7 @@ trait AnalyticsModule {
   implicit def timestamp[A](v: java.time.LocalDateTime): A =>: java.sql.Timestamp
   implicit def date[A](v: java.time.LocalDate): A =>: java.sql.Date
 
-  val setOps: Ops[Dataset]
+  val setOps: Ops[DataSet]
   val streamOps: Ops[DataStream]
   val stdLib: StandardLibrary
 
@@ -218,12 +218,12 @@ trait AnalyticsModule {
   def column[A: Type](str: scala.Predef.String): Unknown =>: A
 
   /**
-   * Loads a [[Dataset]] without type information
+   * Loads a [[DataSet]] without type information
    */
-  def load(path: String): Dataset[Unknown]
+  def load(path: String): DataSet[Unknown]
 
   /**
-   * Execute the [[DataStream]] or [[Dataset]]
+   * Execute the [[DataStream]] or [[DataSet]]
    */
   def run[A](d: DataStream[A]): IO[Error, Seq[A]]
 }

--- a/src/main/scala/scalaz/analytics/AnalyticsModule.scala
+++ b/src/main/scala/scalaz/analytics/AnalyticsModule.scala
@@ -204,10 +204,9 @@ trait AnalyticsModule {
   implicit def long[A](v: scala.Long): A =>: Long
   implicit def float[A](v: scala.Float): A =>: Float
   implicit def double[A](v: scala.Double): A =>: Double
-  implicit def boolean[A](v: scala.Boolean): A =>: Boolean
   implicit def decimal[A](v: scala.BigDecimal): A =>: BigDecimal
   implicit def string[A](v: scala.Predef.String): A =>: String
-  implicit def boolean[A](v: scala.Boolean): A =>: String
+  implicit def boolean[A](v: scala.Boolean): A =>: Boolean
   implicit def byte[A](v: scala.Byte): A =>: Byte
   implicit def `null`[A](v: Null): A =>: Null
   implicit def short[A](v: scala.Short): A =>: Short

--- a/src/main/scala/scalaz/analytics/AnalyticsModule.scala
+++ b/src/main/scala/scalaz/analytics/AnalyticsModule.scala
@@ -20,7 +20,7 @@ trait AnalyticsModule {
   type DataStream[A]
 
   /**
-   * A window is a way o specify a view on a DataStream/Dataset
+   * A window is a way to specify a view on a DataStream/Dataset
    */
   sealed trait Window
 
@@ -29,7 +29,6 @@ trait AnalyticsModule {
     case class SlidingTimeWindow() extends Window
     case class SessionWindow()     extends Window
     // For internal use only
-    // todo would you ever want a GlobalWindow on a DataStream? Probably not?
     case class GlobalWindow private () extends Window
   }
 
@@ -98,20 +97,16 @@ trait AnalyticsModule {
   }
 
   /**
-   * All operations that don't require a bounded input
+   * The dataset/datastream operations of scalaz-analytics
    */
   trait Ops[F[_]] {
     // Unbounded
     def map[A, B](ds: F[A])(f: A =>: B): F[B]
     def filter[A, B](ds: F[A])(f: A =>: Boolean): F[A]
-    // todo add more
 
     // Bounded
-    def fold[A, B](ds: F[A])(window: Window)(initial: A =>: B)(f: (B, A) =>: B): F[B] // todo is `initial` and `f` correct?
+    def fold[A, B](ds: F[A])(window: Window)(initial: A =>: B)(f: (B, A) =>: B): F[B]
     def distinct[A](ds: F[A])(window: Window): F[A]
-    // todo add more
-
-    // todo prototype how joins/unions etc will work
   }
 
   /**

--- a/src/main/scala/scalaz/analytics/LocalAnalyticsModule.scala
+++ b/src/main/scala/scalaz/analytics/LocalAnalyticsModule.scala
@@ -8,7 +8,7 @@ import java.time.{ LocalDate, LocalDateTime }
  * A non distributed implementation of Analytics Module
  */
 trait LocalAnalyticsModule extends AnalyticsModule {
-  override type Dataset[A]    = LocalDataStream
+  override type DataSet[A]    = LocalDataStream
   override type DataStream[A] = LocalDataStream
   override type Type[A]       = LocalType[A]
   override type Unknown       = UnknownType
@@ -117,10 +117,10 @@ trait LocalAnalyticsModule extends AnalyticsModule {
     case class Distinct(d: LocalDataStream, window: Window) extends LocalDataStream
   }
 
-  private val ops: Ops[Dataset] = new Ops[Dataset] {
+  private val ops: Ops[DataSet] = new Ops[DataSet] {
     override def map[A, B](ds: LocalDataStream)(f: A =>: B): LocalDataStream =
       LocalDataStream.Map(ds, f)
-    override def filter[A, B](ds: LocalDataStream)(f: A =>: Boolean): LocalDataStream =
+    override def filter[A](ds: LocalDataStream)(f: A =>: Boolean): LocalDataStream =
       LocalDataStream.Filter(ds, f)
 
     override def fold[A, B](ds: LocalDataStream)(window: Window)(initial: A =>: B)(
@@ -130,7 +130,7 @@ trait LocalAnalyticsModule extends AnalyticsModule {
       LocalDataStream.Distinct(ds, window)
   }
 
-  override val setOps: Ops[Dataset]       = ops
+  override val setOps: Ops[DataSet]       = ops
   override val streamOps: Ops[DataStream] = ops
 
   /**

--- a/src/main/scala/scalaz/analytics/example/SimpleExample.scala
+++ b/src/main/scala/scalaz/analytics/example/SimpleExample.scala
@@ -12,7 +12,7 @@ object SimpleExample {
     println(ds2)
   }
 
-  val ds1: Dataset[Int] =
+  val ds1: DataSet[Int] =
     empty[Int]
       .map(i => i * 7)
       .distinct

--- a/src/main/scala/scalaz/analytics/example/SimpleExample.scala
+++ b/src/main/scala/scalaz/analytics/example/SimpleExample.scala
@@ -7,11 +7,18 @@ import scalaz.analytics.local._
  */
 object SimpleExample {
 
-  def main(args: Array[String]): Unit =
-    println(ds)
+  def main(args: Array[String]): Unit = {
+    println(ds1)
+    println(ds2)
+  }
 
-  val ds: DataStream[Int] =
+  val ds1: Dataset[Int] =
     empty[Int]
       .map(i => i * 7)
-      .distinctBy(i => i % 2)
+      .distinct
+
+  val ds2: DataStream[Int] =
+    emptyStream[Int]
+      .filter(i => i + 1 > 0)
+      .distinct(Window.FixedTimeWindow())
 }


### PR DESCRIPTION
After going through a bunch of design iterations, I think I've settled on a fairly nice API design for the Dataset/DataStream split as well as the encoding of the Operations.

This approach keeps `Dataset` and `DataStream` as two separate APIs from a user perspective which is what we discussed but implements them under the covers both as `LocalDataStream` - where `Dataset` is a specialisation where any Windowed operations are using a `GlobalWindow`.

Its obviously a fairly minimal PR. If people are happy with this, I'll break out a bunch of tasks (which will be much more clearly defined now that we have a clear view of the structure).