### PR TITLE
Aggregations

### DIFF
--- a/src/main/scala/scalaz/analytics/AnalyticsModule.scala
+++ b/src/main/scala/scalaz/analytics/AnalyticsModule.scala
@@ -102,6 +102,7 @@ trait AnalyticsModule {
   trait Ops[F[_]] {
     // Unbounded
     def map[A, B](ds: F[A])(f: A =>: B): F[B]
+    def flatMap[A, B](ds: F[A])(f: A =>: DataSet[B]): F[B]
     def filter[A](ds: F[A])(f: A =>: Boolean): F[A]
 
     // Bounded
@@ -174,6 +175,9 @@ trait AnalyticsModule {
     def map[B: Type](f: (A =>: A) => (A =>: B)): DataSet[B] =
       setOps.map(ds)(f(stdLib.id))
 
+    def flatMap[B: Type](f: (A =>: A) => (A =>: DataSet[B])) =
+      setOps.flatMap(ds)(f(stdLib.id))
+
     def filter(f: (A =>: A) => (A =>: Boolean)): DataSet[A] =
       setOps.filter(ds)(f(stdLib.id))
 
@@ -191,6 +195,9 @@ trait AnalyticsModule {
 
     def map[B: Type](f: (A =>: A) => (A =>: B)): DataStream[B] =
       streamOps.map(ds)(f(stdLib.id))
+
+    def flatMap[B: Type](f: (A =>: A) => (A =>: DataSet[B])) =
+      streamOps.flatMap(ds)(f(stdLib.id))
 
     def filter(f: (A =>: A) => (A =>: Boolean)): DataStream[A] =
       streamOps.filter(ds)(f(stdLib.id))

--- a/src/main/scala/scalaz/analytics/AnalyticsModule.scala
+++ b/src/main/scala/scalaz/analytics/AnalyticsModule.scala
@@ -150,7 +150,7 @@ trait AnalyticsModule {
    */
   implicit class StringSyntax[A](val l: A =>: String) {
     def split(pattern: String): A =>: DataSet[String] = l >>> stdLib.strSplit(pattern)
-    def concat(r: A =>: String): A =>: String = (l &&& r) >>> stdLib.strConcat
+    def concat(r: A =>: String): A =>: String         = (l &&& r) >>> stdLib.strConcat
   }
 
   trait Numeric[A] {

--- a/src/main/scala/scalaz/analytics/AnalyticsModule.scala
+++ b/src/main/scala/scalaz/analytics/AnalyticsModule.scala
@@ -112,7 +112,7 @@ trait AnalyticsModule {
   /**
    * The standard library of scalaz-analytics.
    */
-  trait StandardLibrary extends TupleLibrary {
+  trait StandardLibrary extends TupleLibrary with StringLibrary {
     def id[A: Type]: A =>: A
     def compose[A, B, C](f: B =>: C, g: A =>: B): A =>: C
     def andThen[A, B, C](f: A =>: B, g: B =>: C): A =>: C
@@ -124,6 +124,11 @@ trait AnalyticsModule {
   trait TupleLibrary {
     def fst[A: Type, B]: (A, B) =>: A
     def snd[A, B: Type]: (A, B) =>: B
+  }
+
+  trait StringLibrary {
+    def strSplit(pattern: String): String =>: DataSet[String]
+    def strConcat: (String, String) =>: String
   }
 
   trait Numeric[A] {

--- a/src/main/scala/scalaz/analytics/AnalyticsModule.scala
+++ b/src/main/scala/scalaz/analytics/AnalyticsModule.scala
@@ -131,6 +131,14 @@ trait AnalyticsModule {
     def strConcat: (String, String) =>: String
   }
 
+  /**
+   * A DSL for string operations
+   */
+  implicit class StringSyntax[A](val l: A =>: String) {
+    def split(pattern: String): A =>: DataSet[String] = l >>> stdLib.strSplit(pattern)
+    def concat(r: A =>: String): A =>: String = (l &&& r) >>> stdLib.strConcat
+  }
+
   trait Numeric[A] {
     def typeOf: Type[A] // underlying repr
 

--- a/src/main/scala/scalaz/analytics/AnalyticsModule.scala
+++ b/src/main/scala/scalaz/analytics/AnalyticsModule.scala
@@ -100,13 +100,26 @@ trait AnalyticsModule {
    * The DataSet/DataStream operations of scalaz-analytics
    */
   trait Ops[F[_]] {
-    // Unbounded
+    // Unbounded dataset ops
+    // (These ops require only bounded space, even with unbounded data)
     def map[A, B](ds: F[A])(f: A =>: B): F[B]
     def flatMap[A, B](ds: F[A])(f: A =>: DataSet[B]): F[B]
     def filter[A](ds: F[A])(f: A =>: Boolean): F[A]
+    // Streaming aggregations
+    // (These ops produce cumulative results, some may require unbounded space)
+    def scan[A, B](ds: F[A])(initial: Unit =>: B)(f: (B, A) =>: B): F[B]
 
-    // Bounded
-    def fold[A, B](ds: F[A])(window: Window)(initial: A =>: B)(f: (B, A) =>: B): F[B]
+    def scanAggregateBy[A, K, V](ds: F[A])(g: A =>: K)(initial: Unit =>: V)(
+      f: (V, A) =>: V
+    ): F[(K, V)]
+
+    // Bounded dataset ops
+    // (These ops can only be performed on bounded subsets of data)
+    def fold[A, B](ds: F[A])(window: Window)(initial: Unit =>: B)(f: (B, A) =>: B): F[B]
+
+    def aggregateBy[A, K, V](ds: F[A])(window: Window)(g: A =>: K)(initial: Unit =>: V)(
+      f: (V, A) =>: V
+    ): F[(K, V)]
     def distinct[A](ds: F[A])(window: Window): F[A]
   }
 
@@ -175,14 +188,37 @@ trait AnalyticsModule {
     def map[B: Type](f: (A =>: A) => (A =>: B)): DataSet[B] =
       setOps.map(ds)(f(stdLib.id))
 
-    def flatMap[B: Type](f: (A =>: A) => (A =>: DataSet[B])) =
+    def flatMap[B: Type](f: (A =>: A) => (A =>: DataSet[B])): DataSet[B] =
       setOps.flatMap(ds)(f(stdLib.id))
 
     def filter(f: (A =>: A) => (A =>: Boolean)): DataSet[A] =
       setOps.filter(ds)(f(stdLib.id))
 
-    def fold[B: Type](init: A =>: B)(f: (B, A) =>: B): DataSet[B] =
-      setOps.fold(ds)(Window.GlobalWindow())(init)(f)
+    def scan[B: Type](initial: Unit =>: B)(f: ((B, A) =>: (B, A)) => ((B, A) =>: B)): DataSet[B] =
+      setOps.scan(ds)(initial)(f(stdLib.id))
+
+    def scanAggregate[V: Type](
+      initial: Unit =>: V
+    )(f: ((V, A) =>: (V, A)) => ((V, A) =>: V)): DataSet[(A, V)] =
+      scanAggregateBy(identity)(initial)(f)
+
+    def scanAggregateBy[K, V: Type](
+      g: (A =>: A) => (A =>: K)
+    )(initial: Unit =>: V)(f: ((V, A) =>: (V, A)) => ((V, A) =>: V)): DataSet[(K, V)] =
+      setOps.scanAggregateBy(ds)(g(stdLib.id))(initial)(f(stdLib.id))
+
+    def fold[B: Type](init: Unit =>: B)(f: ((B, A) =>: (B, A)) => ((B, A) =>: B)): DataSet[B] =
+      setOps.fold(ds)(Window.GlobalWindow())(init)(f(stdLib.id))
+
+    def aggregate[V: Type](
+      initial: Unit =>: V
+    )(f: ((V, A) =>: (V, A)) => ((V, A) =>: V)): DataSet[(A, V)] =
+      aggregateBy(identity)(initial)(f)
+
+    def aggregateBy[K, V: Type](
+      g: (A =>: A) => (A =>: K)
+    )(initial: Unit =>: V)(f: ((V, A) =>: (V, A)) => ((V, A) =>: V)): DataSet[(K, V)] =
+      setOps.aggregateBy(ds)(Window.GlobalWindow())(g(stdLib.id))(initial)(f(stdLib.id))
 
     def distinct: DataSet[A] =
       setOps.distinct(ds)(Window.GlobalWindow())
@@ -196,14 +232,41 @@ trait AnalyticsModule {
     def map[B: Type](f: (A =>: A) => (A =>: B)): DataStream[B] =
       streamOps.map(ds)(f(stdLib.id))
 
-    def flatMap[B: Type](f: (A =>: A) => (A =>: DataSet[B])) =
+    def flatMap[B: Type](f: (A =>: A) => (A =>: DataSet[B])): DataStream[B] =
       streamOps.flatMap(ds)(f(stdLib.id))
 
     def filter(f: (A =>: A) => (A =>: Boolean)): DataStream[A] =
       streamOps.filter(ds)(f(stdLib.id))
 
-    def fold[B: Type](window: Window)(init: A =>: B)(f: (B, A) =>: B): DataStream[B] =
-      streamOps.fold(ds)(window)(init)(f)
+    def scan[B: Type](
+      initial: Unit =>: B
+    )(f: ((B, A) =>: (B, A)) => ((B, A) =>: B)): DataStream[B] =
+      streamOps.scan(ds)(initial)(f(stdLib.id))
+
+    def scanAggregate[V: Type](
+      initial: Unit =>: V
+    )(f: ((V, A) =>: (V, A)) => ((V, A) =>: V)): DataStream[(A, V)] =
+      scanAggregateBy(identity)(initial)(f)
+
+    def scanAggregateBy[K, V: Type](
+      g: (A =>: A) => (A =>: K)
+    )(initial: Unit =>: V)(f: ((V, A) =>: (V, A)) => ((V, A) =>: V)): DataStream[(K, V)] =
+      streamOps.scanAggregateBy(ds)(g(stdLib.id))(initial)(f(stdLib.id))
+
+    def fold[B: Type](
+      window: Window
+    )(init: Unit =>: B)(f: ((B, A) =>: (B, A)) => ((B, A) =>: B)): DataStream[B] =
+      streamOps.fold(ds)(window)(init)(f(stdLib.id))
+
+    def aggregate[V: Type](
+      window: Window
+    )(initial: Unit =>: V)(f: ((V, A) =>: (V, A)) => ((V, A) =>: V)): DataStream[(A, V)] =
+      aggregateBy(window)(identity)(initial)(f)
+
+    def aggregateBy[K, V: Type](window: Window)(
+      g: (A =>: A) => (A =>: K)
+    )(initial: Unit =>: V)(f: ((V, A) =>: (V, A)) => ((V, A) =>: V)): DataStream[(K, V)] =
+      streamOps.aggregateBy(ds)(window)(g(stdLib.id))(initial)(f(stdLib.id))
 
     def distinct(window: Window): DataStream[A] =
       streamOps.distinct(ds)(window)

--- a/src/main/scala/scalaz/analytics/LocalAnalyticsModule.scala
+++ b/src/main/scala/scalaz/analytics/LocalAnalyticsModule.scala
@@ -112,9 +112,24 @@ trait LocalAnalyticsModule extends AnalyticsModule {
     case class Map(d: LocalDataStream, f: RowFunction)     extends LocalDataStream
     case class FlatMap(d: LocalDataStream, f: RowFunction) extends LocalDataStream
     case class Filter(d: LocalDataStream, f: RowFunction)  extends LocalDataStream
+    case class Scan(d: LocalDataStream, initial: RowFunction, f: RowFunction)
+        extends LocalDataStream
+    case class ScanAggregateBy(
+      d: LocalDataStream,
+      groupBy: RowFunction,
+      initial: RowFunction,
+      f: RowFunction
+    ) extends LocalDataStream
 
     case class Fold(d: LocalDataStream, initial: RowFunction, f: RowFunction, window: Window)
         extends LocalDataStream
+    case class AggregateBy(
+      d: LocalDataStream,
+      groupBy: RowFunction,
+      initial: RowFunction,
+      f: RowFunction,
+      window: Window
+    ) extends LocalDataStream
     case class Distinct(d: LocalDataStream, window: Window) extends LocalDataStream
   }
 
@@ -125,11 +140,23 @@ trait LocalAnalyticsModule extends AnalyticsModule {
       LocalDataStream.FlatMap(ds, f)
     override def filter[A](ds: LocalDataStream)(f: A =>: Boolean): LocalDataStream =
       LocalDataStream.Filter(ds, f)
+    override def scan[A, B](
+      ds: LocalDataStream
+    )(initial: Unit =>: B)(f: (B, A) =>: B): LocalDataStream =
+      LocalDataStream.Scan(ds, initial, f)
+    override def scanAggregateBy[A, K, V](
+      ds: LocalDataStream
+    )(g: A =>: K)(initial: Unit =>: V)(f: (V, A) =>: V): LocalDataStream =
+      LocalDataStream.ScanAggregateBy(ds, g, initial, f)
 
     override def fold[A, B](
       ds: LocalDataStream
     )(window: Window)(initial: A =>: B)(f: (B, A) =>: B): LocalDataStream =
       LocalDataStream.Fold(ds, initial, f, window)
+    override def aggregateBy[A, K, V](
+      ds: LocalDataStream
+    )(window: Window)(g: A =>: K)(initial: Unit =>: V)(f: (V, A) =>: V): LocalDataStream =
+      LocalDataStream.AggregateBy(ds, g, initial, f, window)
     override def distinct[A](ds: LocalDataStream)(window: Window): LocalDataStream =
       LocalDataStream.Distinct(ds, window)
   }

--- a/src/main/scala/scalaz/analytics/LocalAnalyticsModule.scala
+++ b/src/main/scala/scalaz/analytics/LocalAnalyticsModule.scala
@@ -109,8 +109,9 @@ trait LocalAnalyticsModule extends AnalyticsModule {
   object LocalDataStream {
     case class Empty(rType: Reified) extends LocalDataStream
 
-    case class Map(d: LocalDataStream, f: RowFunction)    extends LocalDataStream
-    case class Filter(d: LocalDataStream, f: RowFunction) extends LocalDataStream
+    case class Map(d: LocalDataStream, f: RowFunction)     extends LocalDataStream
+    case class FlatMap(d: LocalDataStream, f: RowFunction) extends LocalDataStream
+    case class Filter(d: LocalDataStream, f: RowFunction)  extends LocalDataStream
 
     case class Fold(d: LocalDataStream, initial: RowFunction, f: RowFunction, window: Window)
         extends LocalDataStream
@@ -120,6 +121,8 @@ trait LocalAnalyticsModule extends AnalyticsModule {
   private val ops: Ops[DataSet] = new Ops[DataSet] {
     override def map[A, B](ds: LocalDataStream)(f: A =>: B): LocalDataStream =
       LocalDataStream.Map(ds, f)
+    override def flatMap[A, B](ds: LocalDataStream)(f: A =>: DataSet[B]): LocalDataStream =
+      LocalDataStream.FlatMap(ds, f)
     override def filter[A](ds: LocalDataStream)(f: A =>: Boolean): LocalDataStream =
       LocalDataStream.Filter(ds, f)
 

--- a/src/main/scala/scalaz/analytics/LocalAnalyticsModule.scala
+++ b/src/main/scala/scalaz/analytics/LocalAnalyticsModule.scala
@@ -153,6 +153,8 @@ trait LocalAnalyticsModule extends AnalyticsModule {
     case class Product(fab: RowFunction)                      extends RowFunction
     case class Column(colName: String, rType: Reified)        extends RowFunction
     case class ExtractNth(reified: Reified, n: Int)           extends RowFunction
+    case class StrSplit(pattern: String)                      extends RowFunction
+    case object StrConcat                                     extends RowFunction
 
     // constants
     case class IntLiteral(value: Int)             extends RowFunction
@@ -187,6 +189,11 @@ trait LocalAnalyticsModule extends AnalyticsModule {
     override def fst[A: Type, B]: (A, B) =>: A = RowFunction.ExtractNth(Type[A].reified, 0)
 
     override def snd[A, B: Type]: (A, B) =>: B = RowFunction.ExtractNth(Type[B].reified, 1)
+
+    override def strSplit(pattern: String): String =>: DataSet[String] =
+      RowFunction.StrSplit(pattern)
+
+    override def strConcat: (String, String) =>: String = RowFunction.StrConcat
   }
 
   override def empty[A: Type]: LocalDataStream = LocalDataStream.Empty(LocalType.typeOf[A])

--- a/src/main/scala/scalaz/analytics/example/SimpleExample.scala
+++ b/src/main/scala/scalaz/analytics/example/SimpleExample.scala
@@ -10,6 +10,8 @@ object SimpleExample {
   def main(args: Array[String]): Unit = {
     println(ds1)
     println(ds2)
+    println(tupleExample)
+    println(tupleExample2)
   }
 
   val ds1: DataSet[Int] =
@@ -21,4 +23,15 @@ object SimpleExample {
     emptyStream[Int]
       .filter(i => i + 1 > 0)
       .distinct(Window.FixedTimeWindow())
+
+  val tupleExample: DataSet[(Int, Boolean)] =
+    empty[(Int, String)]
+      .map(_ => (4, false))
+      .filter(_._2)
+
+  val tupleExample2: DataSet[(Int, String)] =
+    empty[(Int, String)]
+      .map(_ => (4, false)) // tuple of literals works
+      .map(s => (3, s._1)) // tuple with right side projection
+      .map(s => (s._2, "")) // tuple with left side projection
 }

--- a/src/main/scala/scalaz/analytics/example/SimpleExample.scala
+++ b/src/main/scala/scalaz/analytics/example/SimpleExample.scala
@@ -19,6 +19,12 @@ object SimpleExample {
       .map(i => i * 7)
       .distinct
 
+  val countExample =
+    ds1.fold(0)(va => va._1 + 1)
+
+  val sumExample =
+    ds1.fold(0)(va => va._1 + va._2)
+
   val ds2: DataStream[Int] =
     emptyStream[Int]
       .filter(i => i + 1 > 0)
@@ -34,4 +40,16 @@ object SimpleExample {
       .map(_ => (4, false)) // tuple of literals works
       .map(s => (3, s._1)) // tuple with right side projection
       .map(s => (s._2, "")) // tuple with left side projection
+
+  def cumulativeCountDistinct[A: Type](ds: DataStream[A]): DataStream[(A, Int)] =
+    ds.scanAggregate(0)(_._1 + 1)
+
+  def countDistinct[A: Type](ds: DataSet[A]): DataSet[(A, Int)] =
+    ds.aggregate(0)(_._1 + 1)
+
+  def wordCount(lines: DataSet[String]): DataSet[(String, Int)] =
+    countDistinct(words(lines))
+
+  def words(lines: DataSet[String]): DataSet[String] =
+    lines flatMap (_.split(" "))
 }

--- a/src/main/scala/scalaz/analytics/example/SimpleExample.scala
+++ b/src/main/scala/scalaz/analytics/example/SimpleExample.scala
@@ -51,5 +51,5 @@ object SimpleExample {
     countDistinct(words(lines))
 
   def words(lines: DataSet[String]): DataSet[String] =
-    lines flatMap (_.split(" "))
+    lines.flatMap(_.split(" "))
 }


### PR DESCRIPTION
This pull request adds various aggregation operations. There are variants that produce cumulative results (`scan`, `scanAggregate`, and `scanAggregateBy`) and ones that operate over bounded windows (`fold`, `aggregate`, and `aggregateBy`). Also included in the pull request are basic syntax/ops for tuples and for strings, which will be necessary to implement a complete WordCount example. The essence of the word count example is implemented in the pull request as a handful of defs in the SimpleExample module, but a complete implementation in WordCount.scala is _not_ included.